### PR TITLE
Changed to ml.c5.xlarge training instance type

### DIFF
--- a/fm_amazon_recommender.ipynb
+++ b/fm_amazon_recommender.ipynb
@@ -1104,7 +1104,7 @@
     "    sagemaker.amazon.amazon_estimator.get_image_uri(boto3.Session().region_name, 'factorization-machines', 'latest'),\n",
     "    role, \n",
     "    train_instance_count=1, # Note: instance numbers may be limited on workshop credits \n",
-    "    train_instance_type='ml.c5.large', # Note:'ml.c5.2xlarge' may not be available on workshop credits\n",
+    "    train_instance_type='ml.c5.xlarge', # Note:'ml.c5.2xlarge' may not be available on workshop credits\n",
     "    output_path='s3://{}/{}/output'.format(bucket, prefix),\n",
     "    base_job_name=base,\n",
     "    sagemaker_session=sess)\n",


### PR DESCRIPTION
SageMaker TrainingJob does not support ml.c5.large type (see https://aws.amazon.com/sagemaker/pricing/)